### PR TITLE
FIRMWARE: suppress non ascii code, otherwise following error when lau…

### DIFF
--- a/examples/starter-projects/netshell/firmware.yml
+++ b/examples/starter-projects/netshell/firmware.yml
@@ -182,7 +182,7 @@ configuration:
 
 
 #        -keep-as-directory
-#            if  one source directory is specified, create a root directory contain‐
+#            if  one source directory is specified, create a root directory contain
 #            ing that directory, rather than the contents of the directory.
 
 #    Filesystem filter options


### PR DESCRIPTION
…nching:

ansible@vm-stretch-armhf-1:~/git/dft.git/toolkit/dft$ python3.5 dft build_rootfs --project-file ../../examples/board-support-projects/netshell-board-orange-pi-zero/project.yml

Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "dft/__main__.py", line 58, in <module>
    sys.exit(main())
  File "dft/__main__.py", line 50, in main
    return parser.run()
  File "dft/cli.py", line 381, in run
    self.project.load_definition()
  File "dft/model.py", line 636, in load_definition
    self.firmware = yaml.load(working_file)
  File "/usr/local/lib/python3.5/dist-packages/yaml/__init__.py", line 70, in load
    loader = Loader(stream)
  File "/usr/local/lib/python3.5/dist-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "/usr/local/lib/python3.5/dist-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/usr/local/lib/python3.5/dist-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()
  File "/usr/local/lib/python3.5/dist-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 5350: ordinal not in range(128)